### PR TITLE
Add parameter to set a custom GHE URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ jobs:
 | `pull_request_number`   | TRUE     | The GitHub Pull Request number                       | `${{github.event.pull_request.number}}`|
 | `comment_title`         | TRUE     | The comment title displayed at the top of the comment. It is also used to determine whether the comment already exists and should be edited or not. | `COMPILE RESULT` |
 | `num_lines_to_display`  | FALSE    | The number of lines for the code snippet displayed for each error/warning | `5` |
+| `server_url`            | FALSE    | URL of GitHub Enterprise server (defaults to github.com)  | `https://github.com` |

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   debug_output:
     description: 'Use this input to generate debug prints'
     default: false
+  server_url:
+    description: 'URL of GitHub Enterprise server (defaults to github.com)'
+    default: "https://github.com"
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -202,7 +202,7 @@ function process_compile_output() {
       description = "\n```diff\n" + `${color_mark}Line: ${file_line_start} ` + line.substring(line.indexOf(" ")) + "\n```\n";
 
       // Concatinate both modified path to file and the description
-      var link_with_description = `\nhttps://github.com/${github.context.issue.owner}/${github.context.issue.repo}` +
+      var link_with_description = `\n` + core.getInput('server_url') + `/${github.context.issue.owner}/${github.context.issue.repo}` +
         `/blob/${github.context.sha}/${file_path}#L${file_line_start}-L${file_line_end} ${description} </br>\n`;
 
       matchingStrings.push(link_with_description);

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function process_compile_output() {
       description = "\n```diff\n" + `${color_mark}Line: ${file_line_start} ` + line.substring(line.indexOf(" ")) + "\n```\n";
 
       // Concatinate both modified path to file and the description
-      var link_with_description = `\nhttps://github.com/${github.context.issue.owner}/${github.context.issue.repo}` +
+      var link_with_description = `\n` + core.getInput('server_url') + `/${github.context.issue.owner}/${github.context.issue.repo}` +
         `/blob/${github.context.sha}/${file_path}#L${file_line_start}-L${file_line_end} ${description} </br>\n`;
 
       matchingStrings.push(link_with_description);


### PR DESCRIPTION
Currently, there is a hardcoded URL to github.com. This PR adds another parameter to set a custom GitHub Enterprise URL.